### PR TITLE
Add more adjectives to bot name generation

### DIFF
--- a/src/server/world/services/bot-service/generate-name.ts
+++ b/src/server/world/services/bot-service/generate-name.ts
@@ -1,7 +1,4 @@
 const adjectives = [
-	// base words
-	"Funky",
-	"Funny",
 	// taken mostly from https://gist.github.com/hugsy/8910dc78d208e40de42deb29e62df913
 	"Adventurous",
 	"Accurate",
@@ -51,6 +48,8 @@ const adjectives = [
 	"Fearless",
 	"Flashy",
 	"Flawless",
+	"Funky",
+	"Funny",
 	"Fuzzy",
 	"Genuine",
 	"Giant",


### PR DESCRIPTION
When I initially created the adjective list I found it much larger than necessary and shortened it drastically. The result is a somewhat brief list and a saturated collection of bots with adjectives starting with the letter 'A'.

This pull request is sort of an "immediate" fix for now, extending the list with a more diverse vocabulary. ~~I'd like to go over this one final time in the future, giving at least a few adjectives for all letters A-Z~~ Done!.