### PR TITLE
fix: update direction on movement

### DIFF
--- a/src/client/app/components/controller/use-touch-move.ts
+++ b/src/client/app/components/controller/use-touch-move.ts
@@ -18,13 +18,6 @@ export function useTouchMove() {
 	const [direction, setDirection] = useState(Vector2.zero);
 	const [jumping, setJumping] = useState(false);
 
-	// Only set direction if the input caused the player to move
-	const isMoving = () => {
-		return character?.Humanoid.MoveDirection !== Vector3.zero;
-	};
-
-	// Only set direction if this input started on the left side
-	// of the screen
 	const getSide = (input: InputObject): "left" | "right" => {
 		return input.Position.X < camera.ViewportSize.X / 2 ? "left" : "right";
 	};


### PR DESCRIPTION
This PR addresses a bug in the touch device controller that would break movement if input was cancelled by opening the Roblox menu.

This is fixed by allowing the touch input object to be overridden, and by updating the direction when the humanoid moves instead of when the touch input changes.