### PR TITLE
perf(ui): use ripple for animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@rbxts/react-roblox": "^0.1.0",
 		"@rbxts/reflex": "^4.2.0",
 		"@rbxts/remo": "^1.1.0",
+		"@rbxts/ripple": "0.4.0",
 		"@rbxts/roact": "npm:@rbxts/react-ts@0.9.0",
 		"@rbxts/services": "^1.5.1",
 		"@rbxts/set-timeout": "^1.1.2",

--- a/src/client/app/common/reactive-button/reactive-button.tsx
+++ b/src/client/app/common/reactive-button/reactive-button.tsx
@@ -1,6 +1,7 @@
-import { Spring, blend, joinAnyBindings, lerpBinding, useMotor, useUpdateEffect } from "@rbxts/pretty-react-hooks";
+import { blend, joinAnyBindings, lerpBinding, useUpdateEffect } from "@rbxts/pretty-react-hooks";
+import { spring } from "@rbxts/ripple";
 import Roact from "@rbxts/roact";
-import { useRem } from "client/app/hooks";
+import { useMotion, useRem } from "client/app/hooks";
 import { Button } from "../button";
 import { Frame } from "../frame";
 import { useButtonAnimation } from "./use-button-animation";
@@ -59,16 +60,15 @@ export function ReactiveButton({
 	children,
 }: ReactiveButtonProps) {
 	const rem = useRem();
-	const [sizeAnimation, setSizeAnimation, sizeAnimationApi] = useMotor(0);
+	const [sizeAnimation, sizeMotion] = useMotion(0);
 	const [press, hover, buttonEvents] = useButtonState();
 	const animation = useButtonAnimation(press, hover);
 
 	useUpdateEffect(() => {
 		if (press) {
-			setSizeAnimation(new Spring(-0.1));
+			sizeMotion.to(spring(-0.1, { tension: 300 }));
 		} else {
-			sizeAnimationApi.setState({ velocity: 30 });
-			setSizeAnimation(new Spring(0));
+			sizeMotion.to(spring(0, { impulse: 0.01, tension: 300 }));
 		}
 	}, [press]);
 

--- a/src/client/app/common/reactive-button/use-button-animation.ts
+++ b/src/client/app/common/reactive-button/use-button-animation.ts
@@ -1,5 +1,8 @@
-import { Spring, useMotor, useUpdateEffect } from "@rbxts/pretty-react-hooks";
+import { useUpdateEffect } from "@rbxts/pretty-react-hooks";
+import { spring } from "@rbxts/ripple";
 import Roact, { useMemo } from "@rbxts/roact";
+import { useMotion } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 
 export interface ButtonAnimation {
 	/**
@@ -36,52 +39,40 @@ export interface ButtonAnimation {
  * @returns A `ButtonAnimation` object.
  */
 export function useButtonAnimation(pressedState: boolean, hoveredState: boolean): ButtonAnimation {
-	const [press, setPress] = useMotor(0);
-	const [hover, setHover] = useMotor(0);
-	const [hoverExclusive, setHoverExclusive] = useMotor(0);
-	const [position, setPosition, positionApi] = useMotor(0);
+	const [press, pressMotion] = useMotion(0);
+	const [hover, hoverMotion] = useMotion(0);
+	const [hoverExclusive, hoverExclusiveMotion] = useMotion(0);
+	const [position, positionMotion] = useMotion(0);
 
 	useUpdateEffect(() => {
-		setPress(new Spring(pressedState ? 1 : 0, { frequency: 3 }));
-		setHoverExclusive(
-			new Spring(hoveredState && !pressedState ? 1 : 0, {
-				frequency: hoveredState ? 3 : 1,
-				dampingRatio: hoveredState ? 1 : 1.5,
-			}),
-		);
+		pressMotion.to(spring(pressedState ? 1 : 0, springs.responsive));
+		hoverExclusiveMotion.to(spring(hoveredState && !pressedState ? 1 : 0, springs.responsive));
 	}, [pressedState, hoveredState]);
 
 	useUpdateEffect(() => {
-		setHover(
-			new Spring(hoveredState ? 1 : 0, {
-				frequency: hoveredState ? 3 : 1,
-				dampingRatio: hoveredState ? 1 : 1.5,
-			}),
-		);
+		hoverMotion.to(spring(hoveredState ? 1 : 0, springs.responsive));
 	}, [hoveredState]);
 
 	useUpdateEffect(() => {
 		if (pressedState) {
 			// hovered -> pressed
-			setPosition(new Spring(1, { frequency: 5 }));
+			positionMotion.to(spring(1, springs.responsive));
 		} else if (hoveredState) {
 			// pressed -> hovered
-			setPosition(new Spring(-1, { frequency: 3, dampingRatio: 0.4 }));
-			positionApi.impulse(-100);
+			positionMotion.to(spring(-1, { ...springs.bubbly, impulse: -0.1 }));
 		} else {
 			// pressed -> unhovered, but 'hover' was not true
-			setPosition(new Spring(0, { frequency: 3, dampingRatio: 0.4 }));
-			positionApi.impulse(-75);
+			positionMotion.to(spring(0, { ...springs.bubbly, impulse: -0.07 }));
 		}
 	}, [pressedState]);
 
 	useUpdateEffect(() => {
 		if (hoveredState) {
 			// unhovered -> hovered
-			setPosition(new Spring(-1, { frequency: 5 }));
+			positionMotion.to(spring(-1, springs.responsive));
 		} else {
 			// hovered -> unhovered
-			setPosition(new Spring(0, { frequency: 5 }));
+			positionMotion.to(spring(0, springs.responsive));
 		}
 	}, [hoveredState]);
 

--- a/src/client/app/components/game/game.tsx
+++ b/src/client/app/components/game/game.tsx
@@ -1,16 +1,18 @@
-import { Spring, lerpBinding, useMotor } from "@rbxts/pretty-react-hooks";
+import { lerpBinding } from "@rbxts/pretty-react-hooks";
 import { useSelector } from "@rbxts/react-reflex";
+import { spring } from "@rbxts/ripple";
 import Roact, { useEffect } from "@rbxts/roact";
 import { CanvasOrFrame } from "client/app/common/canvas-or-frame";
+import { useMotion } from "client/app/hooks";
 import { selectWorldSubject } from "client/store/world";
 import { Minimap } from "./minimap";
 
 export function Game() {
 	const inGame = useSelector(selectWorldSubject) !== undefined;
-	const [transition, setTransition] = useMotor(0);
+	const [transition, transitionMotion] = useMotion(0);
 
 	useEffect(() => {
-		setTransition(new Spring(inGame ? 1 : 0, { frequency: 1 }));
+		transitionMotion.to(spring(inGame ? 1 : 0));
 	}, [inGame]);
 
 	return (

--- a/src/client/app/components/game/minimap/minimap-node.tsx
+++ b/src/client/app/components/game/minimap/minimap-node.tsx
@@ -1,7 +1,8 @@
-import { Spring, map, useMotor } from "@rbxts/pretty-react-hooks";
+import { map } from "@rbxts/pretty-react-hooks";
+import { spring } from "@rbxts/ripple";
 import Roact, { useEffect } from "@rbxts/roact";
 import { Image } from "client/app/common/image";
-import { useRem } from "client/app/hooks";
+import { useMotion, useRem } from "client/app/hooks";
 import { images } from "shared/assets";
 import { WORLD_BOUNDS } from "shared/constants";
 import { palette } from "shared/data/palette";
@@ -14,23 +15,19 @@ interface MinimapNodeProps {
 
 export function MinimapNode({ point, rotation = 0, isClient = false }: MinimapNodeProps) {
 	const rem = useRem();
-	const [smoothPoint, setSmoothPoint] = useMotor({ x: point.X, y: point.Y });
-	const [smoothRotation, setSmoothRotation] = useMotor(rotation);
+	const [smoothPoint, smoothPointMotion] = useMotion(point);
+	const [smoothRotation, smoothRotationMotion] = useMotion(rotation);
 
 	const position = smoothPoint.map((point) => {
 		return UDim2.fromScale(
-			map(point.x, -WORLD_BOUNDS, WORLD_BOUNDS, 0, 1),
-			map(point.y, -WORLD_BOUNDS, WORLD_BOUNDS, 0, 1),
+			map(point.X, -WORLD_BOUNDS, WORLD_BOUNDS, 0, 1),
+			map(point.Y, -WORLD_BOUNDS, WORLD_BOUNDS, 0, 1),
 		);
 	});
 
 	useEffect(() => {
-		setSmoothPoint({
-			x: new Spring(point.X, { frequency: 2 }),
-			y: new Spring(point.Y, { frequency: 2 }),
-		});
-
-		setSmoothRotation(new Spring(rotation, { frequency: 2 }));
+		smoothPointMotion.to(spring(point));
+		smoothRotationMotion.to(spring(rotation));
 	}, [point, rotation]);
 
 	return (

--- a/src/client/app/components/menu/home/play-button.tsx
+++ b/src/client/app/components/menu/home/play-button.tsx
@@ -1,10 +1,11 @@
-import { Spring, lerpBinding, useMotor, useTimer } from "@rbxts/pretty-react-hooks";
+import { lerpBinding, useTimer } from "@rbxts/pretty-react-hooks";
+import { spring } from "@rbxts/ripple";
 import Roact from "@rbxts/roact";
 import { Frame } from "client/app/common/frame";
 import { ReactiveButton } from "client/app/common/reactive-button";
 import { Shadow } from "client/app/common/shadow";
 import { Text } from "client/app/common/text";
-import { useRem } from "client/app/hooks";
+import { useMotion, useRem } from "client/app/hooks";
 import { palette } from "shared/data/palette";
 import { remotes } from "shared/remotes";
 import { gradient } from "./utils";
@@ -18,7 +19,7 @@ interface PlayButtonProps {
 export function PlayButton({ anchorPoint, size, position }: PlayButtonProps) {
 	const rem = useRem();
 	const timer = useTimer();
-	const [hover, setHover] = useMotor(0);
+	const [hover, hoverMotion] = useMotion(0);
 
 	const shimmer = timer.value.map((t) => {
 		return 30 * t;
@@ -31,7 +32,7 @@ export function PlayButton({ anchorPoint, size, position }: PlayButtonProps) {
 	return (
 		<ReactiveButton
 			onClick={onClick}
-			onHover={(hovered) => setHover(new Spring(hovered ? 1 : 0))}
+			onHover={(hovered) => hoverMotion.to(spring(hovered ? 1 : 0))}
 			backgroundTransparency={1}
 			anchorPoint={anchorPoint}
 			size={size}
@@ -39,7 +40,7 @@ export function PlayButton({ anchorPoint, size, position }: PlayButtonProps) {
 		>
 			<Shadow
 				shadowColor={Color3.fromRGB(255, 255, 255)}
-				shadowTransparency={0.1}
+				shadowTransparency={lerpBinding(hover, 0.2, 0)}
 				shadowSize={rem(1.25)}
 				shadowPosition={rem(0.25)}
 			>
@@ -48,7 +49,7 @@ export function PlayButton({ anchorPoint, size, position }: PlayButtonProps) {
 
 			<Frame
 				backgroundColor={palette.white0}
-				backgroundTransparency={lerpBinding(hover, 0.05, 0.2)}
+				backgroundTransparency={lerpBinding(hover, 0.1, 0)}
 				cornerRadius={new UDim(0, rem(0.5))}
 				size={new UDim2(1, 0, 1, 0)}
 			>

--- a/src/client/app/components/menu/menu-container.tsx
+++ b/src/client/app/components/menu/menu-container.tsx
@@ -1,9 +1,11 @@
-import { Spring, lerpBinding, useMotor } from "@rbxts/pretty-react-hooks";
+import { lerpBinding } from "@rbxts/pretty-react-hooks";
 import { useSelector } from "@rbxts/react-reflex";
+import { spring } from "@rbxts/ripple";
 import Roact, { useEffect, useMemo, useRef } from "@rbxts/roact";
 import { CanvasOrFrame } from "client/app/common/canvas-or-frame";
 import { DelayRender } from "client/app/common/delay-render";
-import { useRem } from "client/app/hooks";
+import { useMotion, useRem } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { MenuPage, selectCurrentPage, selectIsMenuOpen, selectMenuTransition } from "client/store/menu";
 
 interface MenuContainerProps extends Roact.PropsWithChildren {
@@ -23,10 +25,10 @@ export function MenuContainer({ page, children }: MenuContainerProps) {
 
 	const menuTransition = useSelector(selectMenuTransition);
 	const transitionFrom = useRef(rem(TRANSITION_DEFAULT));
-	const [transition, setTransition] = useMotor(0);
+	const [transition, transitionMotion] = useMotion(0);
 
 	useEffect(() => {
-		setTransition(new Spring(visible ? 1 : 0, { frequency: 3 }));
+		transitionMotion.to(spring(visible ? 1 : 0, springs.gentle));
 	}, [visible]);
 
 	// wrapped in useMemo instead of an effect so that it can update

--- a/src/client/app/components/menu/menu-vignette.tsx
+++ b/src/client/app/components/menu/menu-vignette.tsx
@@ -1,20 +1,23 @@
-import { Spring, lerpBinding, useMotor } from "@rbxts/pretty-react-hooks";
+import { lerpBinding } from "@rbxts/pretty-react-hooks";
 import { useSelector } from "@rbxts/react-reflex";
+import { spring } from "@rbxts/ripple";
 import Roact, { useEffect } from "@rbxts/roact";
 import { Image } from "client/app/common/image";
+import { useMotion } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { selectIsMenuOpen } from "client/store/menu";
 import { images } from "shared/assets";
 import { palette } from "shared/data/palette";
 
 export function MenuVignette() {
 	const open = useSelector(selectIsMenuOpen);
-	const [transition, setTransition] = useMotor(0);
+	const [transition, transitionMotion] = useMotion(0);
 
 	useEffect(() => {
 		if (open) {
-			setTransition(new Spring(1, { frequency: 0.5 }));
+			transitionMotion.to(spring(1, springs.molasses));
 		} else {
-			setTransition(new Spring(0, { frequency: 0.5 }));
+			transitionMotion.to(spring(0, springs.molasses));
 		}
 	}, [open]);
 

--- a/src/client/app/components/menu/navigation/destination.tsx
+++ b/src/client/app/components/menu/navigation/destination.tsx
@@ -1,11 +1,13 @@
-import { Spring, lerpBinding, useMotor } from "@rbxts/pretty-react-hooks";
+import { lerpBinding } from "@rbxts/pretty-react-hooks";
 import { useSelectorCreator } from "@rbxts/react-reflex";
+import { spring } from "@rbxts/ripple";
 import Roact, { useEffect } from "@rbxts/roact";
 import { Image } from "client/app/common/image";
 import { ReactiveButton } from "client/app/common/reactive-button";
 import { Shadow } from "client/app/common/shadow";
 import { Text } from "client/app/common/text";
-import { useRem, useStore } from "client/app/hooks";
+import { useMotion, useRem, useStore } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { MenuPage, selectIsPage } from "client/store/menu";
 import { palette } from "shared/data/palette";
 import { MIN_NAV_REM } from "./constants";
@@ -23,10 +25,10 @@ export function Destination({ page, label, icon, iconAlt, color, order }: Destin
 	const rem = useRem({ minimum: MIN_NAV_REM });
 	const store = useStore();
 	const isPage = useSelectorCreator(selectIsPage, page);
-	const [transition, setTransition] = useMotor(0);
+	const [transition, transitionMotion] = useMotion(0);
 
 	useEffect(() => {
-		setTransition(new Spring(isPage ? 1 : 0));
+		transitionMotion.to(spring(isPage ? 1 : 0, springs.stiff));
 	}, [isPage]);
 
 	return (

--- a/src/client/app/components/stats-rail/stats-card.tsx
+++ b/src/client/app/components/stats-rail/stats-card.tsx
@@ -1,4 +1,4 @@
-import { Spring, useMotor } from "@rbxts/pretty-react-hooks";
+import { spring } from "@rbxts/ripple";
 import Roact, { useEffect, useMemo } from "@rbxts/roact";
 import { CanvasOrFrame } from "client/app/common/canvas-or-frame";
 import { Frame } from "client/app/common/frame";
@@ -6,7 +6,8 @@ import { Group } from "client/app/common/group";
 import { ReactiveButton } from "client/app/common/reactive-button";
 import { Shadow } from "client/app/common/shadow";
 import { Text } from "client/app/common/text";
-import { useRem } from "client/app/hooks";
+import { useMotion, useRem } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { palette } from "shared/data/palette";
 
 interface StatsCardProps {
@@ -30,8 +31,8 @@ export function StatsCard({ emoji, label, value, primary, secondary, enabled, or
 	const secondaryDark = secondary.Lerp(palette.crust, 0.75);
 
 	const rem = useRem();
-	const [transparency, setTransparency] = useMotor(1);
-	const [textWidth, setTextWidth] = useMotor({ label: 0, value: 0 });
+	const [transparency, transparencyMotion] = useMotion(1);
+	const [textWidth, textWidthMotion] = useMotion({ label: 0, value: 0 });
 
 	const size = useMemo(() => {
 		return textWidth.map(({ label, value }) => {
@@ -42,7 +43,7 @@ export function StatsCard({ emoji, label, value, primary, secondary, enabled, or
 	}, [rem]);
 
 	useEffect(() => {
-		setTransparency(new Spring(enabled ? 0 : 0.5, { frequency: 1 }));
+		transparencyMotion.to(spring(enabled ? 0 : 0.5, springs.slow));
 	}, [enabled]);
 
 	return (
@@ -111,7 +112,7 @@ export function StatsCard({ emoji, label, value, primary, secondary, enabled, or
 					position={new UDim2(0, rem(CARD_MARGIN + CARD_EMOJI_WIDTH + CARD_PADDING), 0.5, -rem(0.25))}
 					change={{
 						TextBounds: (rbx) => {
-							setTextWidth({ label: new Spring(rbx.TextBounds.X) });
+							textWidthMotion.to({ label: spring(rbx.TextBounds.X) });
 						},
 					}}
 				/>
@@ -128,7 +129,7 @@ export function StatsCard({ emoji, label, value, primary, secondary, enabled, or
 					position={new UDim2(0, rem(CARD_MARGIN + CARD_EMOJI_WIDTH + CARD_PADDING), 0.5, -rem(0.25))}
 					change={{
 						TextBounds: (rbx) => {
-							setTextWidth({ value: new Spring(rbx.TextBounds.X) });
+							textWidthMotion.to({ value: spring(rbx.TextBounds.X) });
 						},
 					}}
 				/>

--- a/src/client/app/components/world/backdrop/backdrop-blur.tsx
+++ b/src/client/app/components/world/backdrop/backdrop-blur.tsx
@@ -1,10 +1,12 @@
 import Object from "@rbxts/object-utils";
-import { Spring, map, useCamera, useEventListener, useMotor } from "@rbxts/pretty-react-hooks";
+import { map, useCamera, useEventListener } from "@rbxts/pretty-react-hooks";
 import { useSelector } from "@rbxts/react-reflex";
+import { spring } from "@rbxts/ripple";
 import Roact, { useBinding, useEffect, useMemo } from "@rbxts/roact";
 import { RunService } from "@rbxts/services";
 import { Image } from "client/app/common/image";
-import { useSeed } from "client/app/hooks";
+import { useMotion, useSeed } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { selectWorldCamera } from "client/store/world";
 import { images } from "shared/assets";
 import { accents } from "shared/data/palette";
@@ -22,7 +24,7 @@ export function BackdropBlur() {
 	const world = useSelector(selectWorldCamera);
 	const seed = useSeed();
 	const [timer, setTimer] = useBinding(0);
-	const [smoothOffset, setSmoothOffset] = useMotor({ x: world.offset.X, y: world.offset.Y });
+	const [smoothOffset, smoothOffsetMotion] = useMotion(world.offset);
 
 	const color = useMemo(() => {
 		const colors = Object.values(accents);
@@ -37,8 +39,8 @@ export function BackdropBlur() {
 			const noiseX = map(math.noise(t, seed), -0.5, 0.5, -3, 4);
 			const noiseY = map(math.noise(seed, t + 100), -0.5, 0.5, -3, 4);
 
-			const x = mod(noiseX + 0.02 * offset.x, -1, 2);
-			const y = mod(noiseY + 0.02 * offset.y * aspectRatio, -1, 2);
+			const x = mod(noiseX + 0.02 * offset.X, -1, 2);
+			const y = mod(noiseY + 0.02 * offset.Y * aspectRatio, -1, 2);
 
 			return new UDim2(x, 0, y, 0);
 		});
@@ -60,10 +62,7 @@ export function BackdropBlur() {
 	});
 
 	useEffect(() => {
-		setSmoothOffset({
-			x: new Spring(world.offset.X),
-			y: new Spring(world.offset.Y),
-		});
+		smoothOffsetMotion.to(spring(world.offset, springs.world));
 	}, [world.offset]);
 
 	return (

--- a/src/client/app/components/world/candy/candy-item.tsx
+++ b/src/client/app/components/world/candy/candy-item.tsx
@@ -1,8 +1,10 @@
-import { Spring, blend, lerp, map, useMotor, useTimer } from "@rbxts/pretty-react-hooks";
+import { blend, lerp, map, useTimer } from "@rbxts/pretty-react-hooks";
+import { spring } from "@rbxts/ripple";
 import Roact, { joinBindings, memo, useEffect, useMemo } from "@rbxts/roact";
 import { Image } from "client/app/common/image";
 import { Shadow } from "client/app/common/shadow";
-import { useRem, useSeed } from "client/app/hooks";
+import { useMotion, useRem, useSeed } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { images } from "shared/assets";
 import { CandyType } from "shared/store/candy";
 import { mapStrict } from "shared/utils/math-utils";
@@ -21,8 +23,8 @@ function CandyItemComponent({ variant, size, point, color, eatenAt, worldScale }
 	const timer = useTimer();
 	const seed = useSeed();
 
-	const [pointSmooth, setPointSmooth] = useMotor({ x: point.X, y: point.Y });
-	const [transition, setTransition] = useMotor(1);
+	const [pointSmooth, pointMotion] = useMotion(point);
+	const [transition, transitionMotion] = useMotion(1);
 
 	const { position, glow, transparency } = useMemo(() => {
 		const position = timer.value.map((t) => {
@@ -31,7 +33,7 @@ function CandyItemComponent({ variant, size, point, color, eatenAt, worldScale }
 			const point = pointSmooth.getValue();
 			const scale = worldScale.getValue();
 
-			return new UDim2(0, rem(point.x * scale + x), 0, rem(point.y * scale + y));
+			return new UDim2(0, rem(point.X * scale + x), 0, rem(point.Y * scale + y));
 		});
 
 		const glow = timer.value.map((t) => {
@@ -54,12 +56,8 @@ function CandyItemComponent({ variant, size, point, color, eatenAt, worldScale }
 	useEffect(() => {
 		const position = eatenAt || point;
 
-		setPointSmooth({
-			x: new Spring(position.X),
-			y: new Spring(position.Y),
-		});
-
-		setTransition(new Spring(eatenAt ? 1 : 0));
+		pointMotion.to(spring(position, springs.world));
+		transitionMotion.to(spring(eatenAt ? 1 : 0));
 	}, [point, eatenAt]);
 
 	return (

--- a/src/client/app/components/world/candy/candy.tsx
+++ b/src/client/app/components/world/candy/candy.tsx
@@ -1,8 +1,9 @@
-import { Spring, useMotor } from "@rbxts/pretty-react-hooks";
 import { useSelector } from "@rbxts/react-reflex";
+import { spring } from "@rbxts/ripple";
 import Roact, { useBinding, useEffect, useMemo } from "@rbxts/roact";
 import { Group } from "client/app/common/group";
-import { useRem } from "client/app/hooks";
+import { useMotion, useRem } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { selectWorldCamera } from "client/store/world";
 import { CandyItem } from "./candy-item";
 import { useCandyOnScreen } from "./use-candy-on-screen";
@@ -12,10 +13,7 @@ export function Candy() {
 	const world = useSelector(selectWorldCamera);
 	const candyOnScreen = useCandyOnScreen(world.offset, world.scale);
 
-	const [smoothOffset, setSmoothOffset] = useMotor({
-		x: world.offset.X,
-		y: world.offset.Y,
-	});
+	const [smoothOffset, offsetMotion] = useMotion(world.offset);
 	const [scale, setScale] = useBinding(world.scale);
 
 	const children = useMemo(() => {
@@ -43,10 +41,7 @@ export function Candy() {
 	}, [candyOnScreen]);
 
 	useEffect(() => {
-		setSmoothOffset({
-			x: new Spring(world.offset.X),
-			y: new Spring(world.offset.Y),
-		});
+		offsetMotion.to(spring(world.offset, springs.world));
 	}, [world.offset]);
 
 	useEffect(() => {
@@ -56,7 +51,7 @@ export function Candy() {
 	return (
 		<Group
 			position={smoothOffset.map(
-				(offset) => new UDim2(0.5, rem(offset.x * world.scale), 0.5, rem(offset.y * world.scale)),
+				(offset) => new UDim2(0.5, rem(offset.X * world.scale), 0.5, rem(offset.Y * world.scale)),
 			)}
 		>
 			{children}

--- a/src/client/app/components/world/snakes/snake.tsx
+++ b/src/client/app/components/world/snakes/snake.tsx
@@ -10,7 +10,7 @@ interface SnakeProps {
 	readonly snakeOnScreen: SnakeOnScreen;
 	readonly scale: number;
 	readonly offset: Vector2;
-	readonly offsetSmooth: Roact.Binding<{ x: number; y: number }>;
+	readonly offsetSmooth: Roact.Binding<Vector2>;
 	readonly subject?: string;
 }
 

--- a/src/client/app/components/world/snakes/snakes.tsx
+++ b/src/client/app/components/world/snakes/snakes.tsx
@@ -1,8 +1,9 @@
-import { Spring, useMotor } from "@rbxts/pretty-react-hooks";
 import { useSelector } from "@rbxts/react-reflex";
+import { spring } from "@rbxts/ripple";
 import Roact, { useEffect, useMemo } from "@rbxts/roact";
 import { Group } from "client/app/common/group";
-import { useRem } from "client/app/hooks";
+import { useMotion, useRem } from "client/app/hooks";
+import { springs } from "client/app/utils/springs";
 import { selectWorldCamera } from "client/store/world";
 import { Snake } from "./snake";
 import { useSnakesOnScreen } from "./use-snakes-on-screen";
@@ -11,23 +12,16 @@ export function Snakes() {
 	const rem = useRem();
 	const world = useSelector(selectWorldCamera);
 	const snakesOnScreen = useSnakesOnScreen(world.scale, world.offset);
-
-	const [offset, setOffset] = useMotor({
-		x: world.offset.X * world.scale,
-		y: world.offset.Y * world.scale,
-	});
+	const [offset, offsetMotion] = useMotion(world.offset.mul(world.scale));
 
 	const position = useMemo(() => {
-		return offset.map(({ x, y }) => {
-			return new UDim2(0.5, rem(x), 0.5, rem(y));
+		return offset.map(({ X, Y }) => {
+			return new UDim2(0.5, rem(X), 0.5, rem(Y));
 		});
 	}, [rem]);
 
 	useEffect(() => {
-		setOffset({
-			x: new Spring(world.offset.X * world.scale),
-			y: new Spring(world.offset.Y * world.scale),
-		});
+		offsetMotion.to(spring(world.offset.mul(world.scale), springs.world));
 	}, [world.offset, world.scale]);
 
 	return (

--- a/src/client/app/hooks/index.ts
+++ b/src/client/app/hooks/index.ts
@@ -3,6 +3,7 @@ export * from "./use-continuous-angle";
 export * from "./use-defined";
 export * from "./use-font-face";
 export * from "./use-input-device";
+export * from "./use-motion";
 export * from "./use-rem";
 export * from "./use-seed";
 export * from "./use-store";

--- a/src/client/app/hooks/use-motion.ts
+++ b/src/client/app/hooks/use-motion.ts
@@ -1,0 +1,28 @@
+import { Motion, MotionGoal, createMotion } from "@rbxts/ripple";
+import { Binding, useBinding, useEffect, useMemo } from "@rbxts/roact";
+
+export function useMotion(goal: number): LuaTuple<[Binding<number>, Motion<number>]>;
+
+export function useMotion<T extends MotionGoal>(goal: T): LuaTuple<[Binding<T>, Motion<T>]>;
+
+export function useMotion<T extends MotionGoal>(goal: T) {
+	const motion = useMemo(() => {
+		return createMotion(goal, { start: true });
+	}, []);
+
+	const [binding, setValue] = useBinding(motion.get());
+
+	useEffect(() => {
+		return motion.onStep((value) => {
+			setValue(value);
+		});
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			motion.destroy();
+		};
+	}, []);
+
+	return $tuple(binding, motion);
+}

--- a/src/client/app/utils/springs.ts
+++ b/src/client/app/utils/springs.ts
@@ -1,0 +1,9 @@
+import { SpringOptions, config } from "@rbxts/ripple";
+
+export const springs = {
+	...config.spring,
+	bubbly: { tension: 400, friction: 14 },
+	responsive: { tension: 400 },
+	gentle: { tension: 250, friction: 30 },
+	world: { tension: 180, friction: 30 },
+} satisfies { [config: string]: SpringOptions };

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,6 +188,11 @@
   resolved "https://registry.yarnpkg.com/@rbxts/remo/-/remo-1.2.1.tgz#fc6924c03a3e25072d93f4da21eacee04ec0868a"
   integrity sha512-S/eh9zr7fysgsR5Ft5nnO2LgueegMduXOoCVv6l1Flg2Vdbhs1sgTzuSJsJAbxMpvfTWLml9063DzHqP1N0T6g==
 
+"@rbxts/ripple@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@rbxts/ripple/-/ripple-0.4.0.tgz#b362c30185b9a3c0d7f365b7b10bbbdce250c3f8"
+  integrity sha512-KuYrzV6Na8c+NMskhr5VWzjVMFYeL6fBnOU0t3yXNWr5c3iEg3XCEEsEUuXIL+cQYf7x6v9ox4uZIX6Ur72H2Q==
+
 "@rbxts/roact-compat-internal@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@rbxts/roact-compat-internal/-/roact-compat-internal-0.3.0.tgz#9f90658346b72db25508b650c9b4e9e7fa6c708c"


### PR DESCRIPTION
I noticed that a portion of the frames dropped while updating snakes were due to updating the bindings themselves. I suspect this is because Flipper is object-oriented, and creating several classes per tracer per snake may be more expensive than what Ripple does.

## Performance

### Ripple

![image](https://github.com/littensy/roblox-slither/assets/56808540/c15b94c7-c3c6-4457-9bdb-a12e40b1a5a1)

### Flipper

Note that spikes in frame time are consistently much larger.

![image](https://github.com/littensy/roblox-slither/assets/56808540/a97a2c0b-52eb-4183-973c-f245949a04f1)

