### PR TITLE
perf: serialize state for hydration

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"typescript": "~5.0"
 	},
 	"dependencies": {
+		"@rbxts/bitbuffer2": "^1.0.0-ts.0",
 		"@rbxts/flipper": "^2.0.1",
 		"@rbxts/lapis": "0.2.4",
 		"@rbxts/object-utils": "^1.0.4",

--- a/src/client/app/components/world/candy/candy-item.tsx
+++ b/src/client/app/components/world/candy/candy-item.tsx
@@ -49,7 +49,7 @@ function CandyItemComponent({ variant, size, point, color, eatenAt, worldScale }
 	}, [rem]);
 
 	const diameter = useMemo(() => {
-		return variant === "loot" ? rem(2 + 1.5 * math.random()) : mapStrict(size, 1, 20, rem(0.75), rem(3.5));
+		return variant === CandyType.Loot ? rem(2 + 1.5 * math.random()) : mapStrict(size, 1, 20, rem(0.75), rem(3.5));
 	}, [variant, rem]);
 
 	useEffect(() => {

--- a/src/client/app/stories/components/game.story.tsx
+++ b/src/client/app/stories/components/game.story.tsx
@@ -8,6 +8,7 @@ import { store } from "client/store";
 import { LOCAL_USER, WORLD_BOUNDS, WORLD_TICK } from "shared/constants";
 import { getRandomAccent } from "shared/data/palette";
 import { getRandomDefaultSnakeSkin } from "shared/data/skins";
+import { CandyType } from "shared/store/candy";
 import { fillArray } from "shared/utils/object-utils";
 import { createScheduler } from "shared/utils/scheduler";
 
@@ -37,7 +38,7 @@ export = hoarcekat(() => {
 		store.populateCandy(
 			fillArray(512, (index) => ({
 				id: `test-${index}`,
-				type: "default",
+				type: CandyType.Default,
 				position: new Vector2(
 					(math.random() * 2 - 1) * WORLD_BOUNDS * 0.2,
 					(math.random() * 2 - 1) * WORLD_BOUNDS * 0.2,

--- a/src/client/app/stories/components/world.story.tsx
+++ b/src/client/app/stories/components/world.story.tsx
@@ -8,6 +8,7 @@ import { store } from "client/store";
 import { LOCAL_USER, WORLD_TICK } from "shared/constants";
 import { getRandomAccent } from "shared/data/palette";
 import { getRandomDefaultSnakeSkin } from "shared/data/skins";
+import { CandyType } from "shared/store/candy";
 import { fillArray } from "shared/utils/object-utils";
 import { createScheduler } from "shared/utils/scheduler";
 
@@ -36,7 +37,7 @@ export = hoarcekat(() => {
 				position: new Vector2(math.random(-50, 50), math.random(-25, 25)),
 				size: math.random(1, 50),
 				color: getRandomAccent(),
-				type: "default",
+				type: CandyType.Default,
 			})),
 		);
 

--- a/src/client/store/middleware/receiver-middleware.ts
+++ b/src/client/store/middleware/receiver-middleware.ts
@@ -1,5 +1,6 @@
 import { createBroadcastReceiver } from "@rbxts/reflex";
 import { remotes } from "shared/remotes";
+import { deserializeState } from "shared/serdes";
 
 export function receiverMiddleware() {
 	const receiver = createBroadcastReceiver({
@@ -13,7 +14,7 @@ export function receiverMiddleware() {
 	});
 
 	remotes.store.hydrate.connect((state) => {
-		receiver.hydrate(state);
+		receiver.hydrate(deserializeState(state));
 	});
 
 	return receiver.middleware;

--- a/src/server/test/world/candy-service.spec.ts
+++ b/src/server/test/world/candy-service.spec.ts
@@ -17,7 +17,7 @@ export = () => {
 	};
 
 	it("should populate the state with candy", () => {
-		expect(countCandy()).to.equal(CANDY_LIMITS.default);
+		expect(countCandy()).to.equal(CANDY_LIMITS[CandyType.Default]);
 	});
 
 	it("should create new candy when the amount decreases", () => {
@@ -28,11 +28,11 @@ export = () => {
 			store.removeCandy(candy.id);
 		}
 
-		expect(countCandy()).to.equal(CANDY_LIMITS.default - candiesToRemove.size());
+		expect(countCandy()).to.equal(CANDY_LIMITS[CandyType.Default] - candiesToRemove.size());
 		store.flush();
 
 		const newCandies = store.getState(selectCandies);
-		expect(countCandy()).to.equal(CANDY_LIMITS.default);
+		expect(countCandy()).to.equal(CANDY_LIMITS[CandyType.Default]);
 		expect(newCandies.every((candy) => !candiesToRemove.has(candy))).to.equal(true);
 	});
 
@@ -43,9 +43,9 @@ export = () => {
 			store.addCandy({ ...template, id: `__test__${index}` });
 		}
 
-		expect(countCandy()).to.equal(CANDY_LIMITS.default + 10);
+		expect(countCandy()).to.equal(CANDY_LIMITS[CandyType.Default] + 10);
 		store.flush();
-		expect(countCandy()).to.equal(CANDY_LIMITS.default + 10);
+		expect(countCandy()).to.equal(CANDY_LIMITS[CandyType.Default] + 10);
 	});
 
 	it("should create candy when a snake dies", () => {
@@ -65,7 +65,7 @@ export = () => {
 		store.setSnakeIsDead("__test__");
 		store.flush();
 
-		expect(countCandy() > CANDY_LIMITS.default).to.equal(true);
+		expect(countCandy() > CANDY_LIMITS[CandyType.Default]).to.equal(true);
 
 		for (const index of $range(1, 50)) {
 			const candy = initialCandy[index];
@@ -74,7 +74,7 @@ export = () => {
 
 		store.flush();
 
-		expect(countCandy() > CANDY_LIMITS.default).to.equal(true);
+		expect(countCandy() > CANDY_LIMITS[CandyType.Default]).to.equal(true);
 	});
 
 	it("should eat candy when a snake is close", () => {
@@ -97,13 +97,13 @@ export = () => {
 	});
 
 	it("should remove excess droppings", () => {
-		const candies = fillArray(CANDY_LIMITS.dropping + 1, () => {
-			return createCandy({ type: "dropping" });
+		const candies = fillArray(CANDY_LIMITS[CandyType.Dropping] + 1, () => {
+			return createCandy({ type: CandyType.Dropping });
 		});
 		store.populateCandy(candies);
-		expect(countCandy("dropping")).to.equal(CANDY_LIMITS.dropping + 1);
-		removeCandyIfAtLimit("dropping");
-		removeCandyIfAtLimit("dropping");
-		expect(countCandy("dropping")).to.equal(CANDY_LIMITS.dropping);
+		expect(countCandy(CandyType.Dropping)).to.equal(CANDY_LIMITS[CandyType.Dropping] + 1);
+		removeCandyIfAtLimit(CandyType.Dropping);
+		removeCandyIfAtLimit(CandyType.Dropping);
+		expect(countCandy(CandyType.Dropping)).to.equal(CANDY_LIMITS[CandyType.Dropping]);
 	});
 };

--- a/src/server/test/world/world.bench.ts
+++ b/src/server/test/world/world.bench.ts
@@ -9,6 +9,7 @@ import {
 	snakeGrid,
 } from "server/world";
 import { CANDY_LIMITS, WORLD_BOUNDS } from "shared/constants";
+import { CandyType } from "shared/store/candy";
 import { benchmark } from "shared/utils/benchmark";
 import { fillArray } from "shared/utils/object-utils";
 import { disconnectAllSchedulers } from "shared/utils/scheduler";
@@ -43,7 +44,7 @@ async function setup() {
 	}
 
 	// Generate the maximum number of candies
-	store.populateCandy(fillArray(CANDY_LIMITS.default, () => createCandy()));
+	store.populateCandy(fillArray(CANDY_LIMITS[CandyType.Default], () => createCandy()));
 
 	// Schedulers may persist after the benchmark is complete, so we need to
 	// disconnect them manually.

--- a/src/server/world/services/bots/bot-behavior.ts
+++ b/src/server/world/services/bots/bot-behavior.ts
@@ -2,6 +2,7 @@ import Object from "@rbxts/object-utils";
 import { setInterval } from "@rbxts/set-timeout";
 import { store } from "server/store";
 import { getCandy, getRandomPointInWorld, getSnake } from "server/world/utils";
+import { CandyType } from "shared/store/candy";
 import { describeSnakeFromScore, SnakeEntity } from "shared/store/snakes";
 import { map } from "shared/utils/math-utils";
 
@@ -47,7 +48,7 @@ export class BotBehavior {
 
 		let target = candyGrid.nearest(head, 15, (point) => {
 			const candy = getCandy(point.metadata.id);
-			return candy !== undefined && !candy.eatenAt && candy.type === "loot";
+			return candy !== undefined && !candy.eatenAt && candy.type === CandyType.Loot;
 		});
 
 		if (!target) {

--- a/src/server/world/services/candy/candy-helpers.ts
+++ b/src/server/world/services/candy/candy-helpers.ts
@@ -20,7 +20,7 @@ export function createCandy(patch?: Partial<CandyEntity>): CandyEntity {
 
 	const candy: CandyEntity = {
 		id: `${nextCandyId++}`,
-		type: "default",
+		type: CandyType.Default,
 		size: math.min(random.NextInteger(1, 6), random.NextInteger(1, 6)),
 		position: getRandomPointNearWorldOrigin(0.95),
 		color: getRandomAccent(),
@@ -101,10 +101,10 @@ export function dropCandyWhileBoosting(id: string) {
 			const candy = createCandy({
 				size: random.NextInteger(1, 5),
 				position: tail,
-				type: "dropping",
+				type: CandyType.Dropping,
 			});
 
-			removeCandyIfAtLimit("dropping");
+			removeCandyIfAtLimit(CandyType.Dropping);
 
 			store.addCandy(candy);
 		};
@@ -158,13 +158,13 @@ export function dropCandyOnDeath(id: string): void {
 
 		return createCandy({
 			position,
-			type: "loot",
+			type: CandyType.Loot,
 			size: math.ceil(sum / total),
 			color: skin.tint,
 		});
 	});
 
-	removeCandyIfAtLimit("loot");
+	removeCandyIfAtLimit(CandyType.Loot);
 
 	store.populateCandy(candies);
 }

--- a/src/server/world/services/candy/candy.ts
+++ b/src/server/world/services/candy/candy.ts
@@ -1,6 +1,6 @@
 import { store } from "server/store";
 import { CANDY_LIMITS, CANDY_TICK_PHASE, WORLD_TICK } from "shared/constants";
-import { selectCandyCount } from "shared/store/candy";
+import { CandyType, selectCandyCount } from "shared/store/candy";
 import { identifySnake, selectAliveSnakesById } from "shared/store/snakes";
 import { createScheduler } from "shared/utils/scheduler";
 
@@ -17,9 +17,9 @@ createScheduler({
 // keep the amount of candy in the world at a constant size
 // if the amount of candy is less than the max, create more
 store.subscribe(
-	selectCandyCount("default"),
-	(count) => count < CANDY_LIMITS.default,
-	(count) => populateCandy(CANDY_LIMITS.default - count),
+	selectCandyCount(CandyType.Default),
+	(count) => count < CANDY_LIMITS[CandyType.Default],
+	(count) => populateCandy(CANDY_LIMITS[CandyType.Default] - count),
 );
 
 store.observe(selectAliveSnakesById, identifySnake, ({ id }) => {
@@ -34,4 +34,4 @@ store.observe(selectAliveSnakesById, identifySnake, ({ id }) => {
 	};
 });
 
-populateCandy(CANDY_LIMITS.default);
+populateCandy(CANDY_LIMITS[CandyType.Default]);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,9 +13,9 @@ export const CANDY_TICK_PHASE = 0.33 * WORLD_TICK;
 export const COLLISION_TICK_PHASE = 0.66 * WORLD_TICK;
 
 export const CANDY_LIMITS: { readonly [K in CandyType]: number } = {
-	default: 4096,
-	dropping: 256,
-	loot: 384,
+	[CandyType.Default]: 4096,
+	[CandyType.Dropping]: 256,
+	[CandyType.Loot]: 384,
 };
 
 export const SNAKE_SPEED = 5;

--- a/src/shared/remotes.ts
+++ b/src/shared/remotes.ts
@@ -3,12 +3,12 @@ import { Client, createRemotes, namespace, remote, Server, throttleMiddleware } 
 import { t } from "@rbxts/t";
 
 import { WORLD_TICK } from "./constants";
-import { SharedState } from "./store";
+import { SharedStateSerialized } from "./serdes";
 
 export const remotes = createRemotes({
 	store: namespace({
 		dispatch: remote<Client, [actions: BroadcastAction[]]>(),
-		hydrate: remote<Client, [state: SharedState]>(),
+		hydrate: remote<Client, [state: SharedStateSerialized]>(),
 		start: remote<Server>(),
 	}),
 

--- a/src/shared/serdes/handlers/serdes-candy.ts
+++ b/src/shared/serdes/handlers/serdes-candy.ts
@@ -1,0 +1,51 @@
+import BitBuffer from "@rbxts/bitbuffer2";
+import { CandyEntity, CandyState } from "shared/store/candy";
+
+import { readColor3, readVector2, writeColor3, writeVector2 } from "../utils";
+
+export interface CandyStateSerialized {
+	[id: string]: string;
+}
+
+export function serializeCandy(state: CandyState): CandyStateSerialized {
+	const serialized: CandyStateSerialized = {};
+
+	for (const [id, candy] of pairs(state)) {
+		serialized[id] = serializeCandyEntity(candy);
+	}
+
+	return serialized;
+}
+
+export function deserializeCandy(state: CandyStateSerialized): CandyState {
+	const deserialized: Writable<CandyState> = {};
+
+	for (const [id, candy] of pairs(state)) {
+		deserialized[id] = deserializeCandyEntity(candy, id as string);
+	}
+
+	return deserialized;
+}
+
+export function serializeCandyEntity(candy: CandyEntity): string {
+	const buffer = new BitBuffer();
+
+	buffer.WriteInt(8, candy.type);
+	buffer.WriteFloat32(candy.size);
+	writeVector2(buffer, candy.position);
+	writeColor3(buffer, candy.color);
+
+	return buffer.ToString();
+}
+
+export function deserializeCandyEntity(data: string, id: string): CandyEntity {
+	const buffer = BitBuffer.FromString(data);
+
+	return {
+		id,
+		type: buffer.ReadInt(8),
+		size: buffer.ReadFloat32(),
+		position: readVector2(buffer),
+		color: readColor3(buffer),
+	};
+}

--- a/src/shared/serdes/handlers/serdes-snake.ts
+++ b/src/shared/serdes/handlers/serdes-snake.ts
@@ -1,0 +1,61 @@
+import BitBuffer from "@rbxts/bitbuffer2";
+import { SnakeEntity, SnakesState } from "shared/store/snakes";
+
+import { readArray, readVector2, writeArray, writeVector2 } from "../utils";
+
+export interface SnakesStateSerialized {
+	[id: string]: string;
+}
+
+export function serializeSnakes(state: SnakesState): SnakesStateSerialized {
+	const snakes: SnakesStateSerialized = {};
+
+	for (const [id, snake] of pairs(state)) {
+		snakes[id] = serializeSnakeEntity(snake);
+	}
+
+	return snakes;
+}
+
+export function deserializeSnakes(state: SnakesStateSerialized): SnakesState {
+	const snakes: Writable<SnakesState> = {};
+
+	for (const [id, snake] of pairs(state)) {
+		snakes[id] = deserializeSnakeEntity(snake, id as string);
+	}
+
+	return snakes;
+}
+
+export function serializeSnakeEntity(snake: SnakeEntity): string {
+	const buffer = new BitBuffer();
+
+	buffer.WriteString(snake.name);
+	writeVector2(buffer, snake.head);
+	buffer.WriteFloat32(snake.angle);
+	buffer.WriteFloat32(snake.desiredAngle);
+	buffer.WriteUInt(32, snake.score);
+	buffer.WriteBool(snake.boost);
+	writeArray(buffer, snake.tracers, writeVector2);
+	buffer.WriteString(snake.skin);
+	buffer.WriteBool(snake.dead);
+
+	return buffer.ToString();
+}
+
+export function deserializeSnakeEntity(data: string, id: string): SnakeEntity {
+	const buffer = BitBuffer.FromString(data);
+
+	return {
+		id,
+		name: buffer.ReadString(),
+		head: readVector2(buffer),
+		angle: buffer.ReadFloat32(),
+		desiredAngle: buffer.ReadFloat32(),
+		score: buffer.ReadUInt(32),
+		boost: buffer.ReadBool(),
+		tracers: readArray(buffer, readVector2),
+		skin: buffer.ReadString(),
+		dead: buffer.ReadBool(),
+	};
+}

--- a/src/shared/serdes/index.ts
+++ b/src/shared/serdes/index.ts
@@ -1,0 +1,43 @@
+import { SharedState } from "shared/store";
+import { CandyState } from "shared/store/candy";
+import { SnakesState } from "shared/store/snakes";
+
+import { CandyStateSerialized, deserializeCandy, serializeCandy } from "./handlers/serdes-candy";
+import { deserializeSnakes, serializeSnakes, SnakesStateSerialized } from "./handlers/serdes-snake";
+
+export interface SharedStateSerialized extends Omit<SharedState, "candy" | "snakes"> {
+	candy?: CandyStateSerialized;
+	snakes?: SnakesStateSerialized;
+}
+
+interface SharedStateForHydrate extends Omit<SharedState, "candy" | "snakes"> {
+	candy?: CandyState;
+	snakes?: SnakesState;
+}
+
+// Store the last serialized state to avoid unnecessary re-computations
+let lastSerialized: SharedStateSerialized | undefined;
+let lastState: SharedStateForHydrate | undefined;
+
+export function serializeState(state: SharedStateForHydrate): SharedStateSerialized {
+	if (state === lastState) {
+		return lastSerialized!;
+	}
+
+	lastState = state;
+	lastSerialized = {
+		...state,
+		candy: state.candy && serializeCandy(state.candy),
+		snakes: state.snakes && serializeSnakes(state.snakes),
+	};
+
+	return lastSerialized;
+}
+
+export function deserializeState(state: SharedStateSerialized): SharedStateForHydrate {
+	return {
+		...state,
+		candy: state.candy && deserializeCandy(state.candy),
+		snakes: state.snakes && deserializeSnakes(state.snakes),
+	};
+}

--- a/src/shared/serdes/utils.ts
+++ b/src/shared/serdes/utils.ts
@@ -1,0 +1,47 @@
+import BitBuffer from "@rbxts/bitbuffer2";
+
+export function writeVector2(buffer: BitBuffer, vector: Vector2) {
+	buffer.WriteFloat32(vector.X);
+	buffer.WriteFloat32(vector.Y);
+}
+
+export function readVector2(buffer: BitBuffer) {
+	const x = buffer.ReadFloat32();
+	const y = buffer.ReadFloat32();
+	return new Vector2(x, y);
+}
+
+export function writeColor3(buffer: BitBuffer, color: Color3) {
+	const hex = color.ToHex();
+	const int = tonumber(hex, 16) ?? 0;
+	buffer.WriteUInt(24, int);
+}
+
+export function readColor3(buffer: BitBuffer) {
+	const int = buffer.ReadUInt(24);
+	const hex = string.format("%x", int);
+	return Color3.fromHex(hex);
+}
+
+export function writeArray<T extends defined>(
+	buffer: BitBuffer,
+	array: readonly T[],
+	write: (buffer: BitBuffer, value: T) => void,
+) {
+	buffer.WriteUInt(16, array.size());
+
+	for (const value of array) {
+		write(buffer, value);
+	}
+}
+
+export function readArray<T extends defined>(buffer: BitBuffer, read: (buffer: BitBuffer) => T): T[] {
+	const size = buffer.ReadUInt(16);
+	const array: T[] = [];
+
+	for (const _ of $range(1, size)) {
+		array.push(read(buffer));
+	}
+
+	return array;
+}

--- a/src/shared/store/candy/candy-selectors.ts
+++ b/src/shared/store/candy/candy-selectors.ts
@@ -34,7 +34,7 @@ export const selectCandyCount = (filter?: CandyType) => {
 		let size = 0;
 
 		for (const [, candy] of pairs(byId)) {
-			if (candy.eatenAt || (filter && candy.type !== filter)) {
+			if (candy.eatenAt || (filter !== undefined && candy.type !== filter)) {
 				continue;
 			}
 

--- a/src/shared/store/candy/candy-slice.ts
+++ b/src/shared/store/candy/candy-slice.ts
@@ -14,7 +14,11 @@ export interface CandyEntity {
 	readonly eatenAt?: Vector2;
 }
 
-export type CandyType = "default" | "loot" | "dropping";
+export enum CandyType {
+	Default,
+	Loot,
+	Dropping,
+}
 
 const initialState: CandyState = {};
 

--- a/src/shared/test/serdes/serdes-candy.spec.ts
+++ b/src/shared/test/serdes/serdes-candy.spec.ts
@@ -1,0 +1,62 @@
+/// <reference types="@rbxts/testez/globals" />
+
+import { HttpService } from "@rbxts/services";
+import { getRandomAccent } from "shared/data/palette";
+import {
+	deserializeCandy,
+	deserializeCandyEntity,
+	serializeCandy,
+	serializeCandyEntity,
+} from "shared/serdes/handlers/serdes-candy";
+import { CandyEntity, CandyState } from "shared/store/candy";
+
+export = () => {
+	function generateCandy(id?: string): CandyEntity {
+		return {
+			id: id ?? HttpService.GenerateGUID(false),
+			type: math.random(0, 2),
+			size: math.random(),
+			position: new Vector2(math.random(), math.random()),
+			color: getRandomAccent(),
+		};
+	}
+
+	function assertCandyEqual(candy: CandyEntity, deserialized: CandyEntity) {
+		for (const [key, value] of pairs(candy)) {
+			if (key === "size") {
+				expect(value).to.be.near(deserialized[key]);
+			} else {
+				expect(value).to.equal(deserialized[key]);
+			}
+		}
+	}
+
+	it("should serialize an entity", () => {
+		const candy: CandyEntity = generateCandy();
+		const serialized = serializeCandyEntity(candy);
+		const deserialized = deserializeCandyEntity(serialized, candy.id);
+		assertCandyEqual(candy, deserialized);
+	});
+
+	it("should serialize a record of entities", () => {
+		const state: CandyState = {
+			"1": generateCandy("1"),
+			"2": generateCandy("2"),
+			"3": generateCandy("3"),
+		};
+		const serialized = serializeCandy(state);
+		const deserialized = deserializeCandy(serialized);
+
+		for (const [id, candy] of pairs(state)) {
+			expect(deserialized[id]).to.be.ok();
+			assertCandyEqual(candy, deserialized[id]!);
+		}
+	});
+
+	it("should compress the data", () => {
+		const candy = generateCandy();
+		const serialized = serializeCandyEntity(candy);
+		const json = HttpService.JSONEncode(candy);
+		expect(serialized.size() < json.size()).to.equal(true);
+	});
+};

--- a/src/shared/test/serdes/serdes-snake.spec.ts
+++ b/src/shared/test/serdes/serdes-snake.spec.ts
@@ -1,0 +1,71 @@
+/// <reference types="@rbxts/testez/globals" />
+
+import { shallowEqual } from "@rbxts/reflex";
+import { HttpService } from "@rbxts/services";
+import { getRandomDefaultSnakeSkin } from "shared/data/skins";
+import {
+	deserializeSnakeEntity,
+	deserializeSnakes,
+	serializeSnakeEntity,
+	serializeSnakes,
+} from "shared/serdes/handlers/serdes-snake";
+import { SnakeEntity, SnakesState } from "shared/store/snakes";
+import { fillArray } from "shared/utils/object-utils";
+
+export = () => {
+	function generateSnake(id?: string): SnakeEntity {
+		return {
+			id: id ?? HttpService.GenerateGUID(false),
+			name: HttpService.GenerateGUID(false),
+			head: new Vector2(math.random(), math.random()),
+			angle: math.random() * math.pi * 2,
+			desiredAngle: math.random() * math.pi * 2,
+			score: math.random(0, 10000),
+			boost: math.random() > 0.5,
+			tracers: fillArray(10, () => new Vector2(math.random(), math.random())),
+			skin: getRandomDefaultSnakeSkin().id,
+			dead: math.random() > 0.5,
+		};
+	}
+
+	function assertSnakeEqual(snake: SnakeEntity, deserialized: SnakeEntity) {
+		for (const [key, value] of pairs(snake)) {
+			if (key === "tracers") {
+				assert(shallowEqual(value, deserialized[key]), "tracers are not equal");
+			} else if (key === "angle" || key === "desiredAngle") {
+				expect(value).to.be.near(deserialized[key], 0.0001);
+			} else {
+				expect(value).to.equal(deserialized[key]);
+			}
+		}
+	}
+
+	it("should serialize an entity", () => {
+		const snake: SnakeEntity = generateSnake();
+		const serialized = serializeSnakeEntity(snake);
+		const deserialized = deserializeSnakeEntity(serialized, snake.id);
+		assertSnakeEqual(snake, deserialized);
+	});
+
+	it("should serialize a record of entities", () => {
+		const state: SnakesState = {
+			"1": generateSnake("1"),
+			"2": generateSnake("2"),
+			"3": generateSnake("3"),
+		};
+		const serialized = serializeSnakes(state);
+		const deserialized = deserializeSnakes(serialized);
+
+		for (const [id, snake] of pairs(state)) {
+			expect(deserialized[id]).to.be.ok();
+			assertSnakeEqual(snake, deserialized[id]!);
+		}
+	});
+
+	it("should compress the data", () => {
+		const snake = generateSnake();
+		const serialized = serializeSnakeEntity(snake);
+		const json = HttpService.JSONEncode(snake);
+		expect(serialized.size() < json.size()).to.equal(true);
+	});
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,11 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
+"@rbxts/bitbuffer2@^1.0.0-ts.0":
+  version "1.0.0-ts.0"
+  resolved "https://registry.yarnpkg.com/@rbxts/bitbuffer2/-/bitbuffer2-1.0.0-ts.0.tgz#83f5576b40877e952d04506980fdd16657b9f78f"
+  integrity sha512-Ly4y6gO5oVUubCFQLJZe9bc8u9jRGPKFoR0R4KSH689PxFQcKf5M5XMQG90DsAbhMk0KXZ2jKYiZuXb6ONBNuQ==
+
 "@rbxts/compiler-types@^2.1.1-types.0":
   version "2.1.1-types.0"
   resolved "https://registry.yarnpkg.com/@rbxts/compiler-types/-/compiler-types-2.1.1-types.0.tgz#a1f02b57402dffec474dd6656ec1d8a897b9756b"


### PR DESCRIPTION
Implements serialization with BitBuffer to compress snake and candy data before sending it over to clients. Serialization is complete in roughly 10ms and saves ~180 kilobytes of data (260,000 → 80,000).

The candy entity's `type` property is now an enum to store it as an integer instead of a string. In the future, the removal of unsafe type casts (see `broadcaster-middleware` lines 19 & 22) would be preferred if possible, but it does not seem likely, so I will leave it as-is.

Resolves #29