### PR TITLE
fix: outline uniformity

### DIFF
--- a/src/client/app/common/outline.tsx
+++ b/src/client/app/common/outline.tsx
@@ -17,6 +17,10 @@ interface OutlineProps extends Roact.PropsWithChildren {
 	readonly cornerRadius?: UDim | Roact.Binding<UDim>;
 }
 
+function ceilEven(n: number) {
+	return math.ceil(n / 2) * 2;
+}
+
 export function Outline({
 	outlineTransparency = 0,
 	innerColor = palette.white,
@@ -36,7 +40,7 @@ export function Outline({
 
 	const innerStyle = useMemo(() => {
 		const size = composeBindings(innerThickness!, (thickness) => {
-			return new UDim2(1, math.round(-2 * thickness), 1, math.round(-2 * thickness));
+			return new UDim2(1, ceilEven(-2 * thickness), 1, ceilEven(-2 * thickness));
 		});
 
 		const position = composeBindings(innerThickness!, (thickness) => {


### PR DESCRIPTION
Fixes small inconsistencies in the even-ness of the Outline component.

![image](https://github.com/littensy/roblox-slither/assets/56808540/06a083ff-369b-4581-9d00-d30ea61c0dba)
