### PR TITLE
refactor: do not run profiler in production

### DIFF
--- a/src/client/app/index.client.tsx
+++ b/src/client/app/index.client.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from "@rbxts/react-roblox";
 import Roact, { Portal, StrictMode } from "@rbxts/roact";
-import { Players } from "@rbxts/services";
+import { Players, RunService } from "@rbxts/services";
 
 import { App } from "./app";
 import { RootProvider } from "./providers/root-provider";
@@ -9,7 +9,9 @@ import { profileAllComponents } from "./utils/profiler";
 const root = createRoot(new Instance("Folder"));
 const target = Players.LocalPlayer.WaitForChild("PlayerGui");
 
-profileAllComponents();
+if (RunService.IsStudio()) {
+	profileAllComponents();
+}
 
 root.render(
 	<StrictMode>


### PR DESCRIPTION
Limits the component profiler to run in Roblox Studio only.