### PR TITLE
build: cancel outdated pending deploy jobs

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -16,6 +16,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: canary_environment
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: production_environment
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancels pending deploy jobs (mostly for canary branch which is automatic) when consecutive merges are made.