### PR TITLE
fix: check players already in game

### DIFF
--- a/src/server/players/services/character.ts
+++ b/src/server/players/services/character.ts
@@ -1,5 +1,4 @@
-import { Players } from "@rbxts/services";
-import { Character, promiseCharacter, promisePlayerDisconnected } from "shared/utils/player-utils";
+import { Character, onPlayerAdded, promiseCharacter, promisePlayerDisconnected } from "shared/utils/player-utils";
 
 export async function initCharacterService() {
 	function onSpawn(character: Character) {
@@ -14,7 +13,7 @@ export async function initCharacterService() {
 		}
 	}
 
-	Players.PlayerAdded.Connect((player) => {
+	onPlayerAdded((player) => {
 		const characterAdded = player.CharacterAdded.Connect((character) => {
 			promiseCharacter(character).then(onSpawn);
 

--- a/src/server/players/services/save.ts
+++ b/src/server/players/services/save.ts
@@ -5,7 +5,7 @@ import { sounds } from "shared/assets";
 import { palette } from "shared/constants/palette";
 import { remotes } from "shared/remotes";
 import { defaultPlayerSave, playerSaveSchema, selectPlayerSave } from "shared/store/saves";
-import { promisePlayerDisconnected } from "shared/utils/player-utils";
+import { onPlayerAdded, promisePlayerDisconnected } from "shared/utils/player-utils";
 
 const collection = createCollection("players", {
 	defaultData: defaultPlayerSave,
@@ -13,11 +13,7 @@ const collection = createCollection("players", {
 });
 
 export async function initSaveService() {
-	Players.PlayerAdded.Connect(loadPlayerSave);
-
-	for (const player of Players.GetPlayers()) {
-		loadPlayerSave(player);
-	}
+	onPlayerAdded(loadPlayerSave);
 }
 
 async function loadPlayerSave(player: Player) {

--- a/src/server/players/services/scoreboard.ts
+++ b/src/server/players/services/scoreboard.ts
@@ -1,10 +1,9 @@
-import { Players } from "@rbxts/services";
 import { store } from "server/store";
 import { selectSnakeById } from "shared/store/snakes";
-import { promisePlayerDisconnected } from "shared/utils/player-utils";
+import { onPlayerAdded, promisePlayerDisconnected } from "shared/utils/player-utils";
 
 export async function initScoreboardService() {
-	Players.PlayerAdded.Connect((player) => {
+	onPlayerAdded((player) => {
 		const stats = new Instance("Folder");
 		stats.Name = "leaderstats";
 		stats.Parent = player;

--- a/src/shared/utils/player-utils.ts
+++ b/src/shared/utils/player-utils.ts
@@ -36,3 +36,13 @@ export function getPlayerByName(name: string) {
 		return player;
 	}
 }
+
+export function onPlayerAdded(callback: (player: Player) => void) {
+	const connection = Players.PlayerAdded.Connect(callback);
+
+	for (const player of Players.GetPlayers()) {
+		callback(player);
+	}
+
+	return () => connection.Disconnect();
+}


### PR DESCRIPTION
`PlayerAdded` doesn't fire for players already in the game at the time of connection, so run the listener for these missed players.

Fixes rare issues with players falling into the void.