### PR TITLE
build: run deployment actions on ubuntu

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -49,7 +49,7 @@ jobs:
           path: place.rbxlx
 
   deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     environment: canary
     needs: build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           path: place.rbxlx
 
   deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     environment: production
     needs: build
 


### PR DESCRIPTION
Migrate deployment jobs to run on `ubuntu-latest` instead of `self-hosted`.